### PR TITLE
Rename project from redis-starter-rust to kafka-starter-rust

### DIFF
--- a/compiled_starters/rust/.codecrafters/compile.sh
+++ b/compiled_starters/rust/.codecrafters/compile.sh
@@ -8,4 +8,4 @@
 
 set -e # Exit on failure
 
-cargo build --release --target-dir=/tmp/codecrafters-redis-target --manifest-path Cargo.toml
+cargo build --release --target-dir=/tmp/codecrafters-kafka-target --manifest-path Cargo.toml

--- a/compiled_starters/rust/.codecrafters/run.sh
+++ b/compiled_starters/rust/.codecrafters/run.sh
@@ -8,4 +8,4 @@
 
 set -e # Exit on failure
 
-exec /tmp/codecrafters-redis-target/release/redis-starter-rust "$@"
+exec /tmp/codecrafters-kafka-target/release/kafka-starter-rust "$@"

--- a/compiled_starters/rust/Cargo.lock
+++ b/compiled_starters/rust/Cargo.lock
@@ -189,7 +189,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "redis-starter-rust"
+name = "kafka-starter-rust"
 version = "0.1.0"
 dependencies = [
  "anyhow",

--- a/compiled_starters/rust/Cargo.toml
+++ b/compiled_starters/rust/Cargo.toml
@@ -6,7 +6,7 @@
 #
 # DON'T EDIT THIS!
 [package]
-name = "redis-starter-rust"
+name = "kafka-starter-rust"
 version = "0.1.0"
 authors = ["Codecrafters <hello@codecrafters.io>"]
 edition = "2021"

--- a/compiled_starters/rust/your_program.sh
+++ b/compiled_starters/rust/your_program.sh
@@ -14,11 +14,11 @@ set -e # Exit early if any commands fail
 # - Edit .codecrafters/compile.sh to change how your program compiles remotely
 (
   cd "$(dirname "$0")" # Ensure compile steps are run within the repository directory
-  cargo build --release --target-dir=/tmp/codecrafters-redis-target --manifest-path Cargo.toml
+  cargo build --release --target-dir=/tmp/codecrafters-kafka-target --manifest-path Cargo.toml
 )
 
 # Copied from .codecrafters/run.sh
 #
 # - Edit this to change how your program runs locally
 # - Edit .codecrafters/run.sh to change how your program runs remotely
-exec /tmp/codecrafters-redis-target/release/redis-starter-rust "$@"
+exec /tmp/codecrafters-kafka-target/release/kafka-starter-rust "$@"

--- a/dockerfiles/rust-1.77.Dockerfile
+++ b/dockerfiles/rust-1.77.Dockerfile
@@ -6,9 +6,9 @@ WORKDIR /app
 # .git & README.md are unique per-repository. We ignore them on first copy to prevent cache misses
 COPY --exclude=.git --exclude=README.md . /app
 
-RUN cargo build --release --target-dir=/tmp/codecrafters-redis-target
+RUN cargo build --release --target-dir=/tmp/codecrafters-kafka-target
 
-RUN echo "cd \${CODECRAFTERS_REPOSITORY_DIR} && cargo build --release --target-dir=/tmp/codecrafters-redis-target --manifest-path Cargo.toml" > /codecrafters-precompile.sh
+RUN echo "cd \${CODECRAFTERS_REPOSITORY_DIR} && cargo build --release --target-dir=/tmp/codecrafters-kafka-target --manifest-path Cargo.toml" > /codecrafters-precompile.sh
 RUN chmod +x /codecrafters-precompile.sh
 
 ENV CODECRAFTERS_DEPENDENCY_FILE_PATHS="Cargo.toml,Cargo.lock"

--- a/solutions/rust/01-vi6/code/.codecrafters/compile.sh
+++ b/solutions/rust/01-vi6/code/.codecrafters/compile.sh
@@ -8,4 +8,4 @@
 
 set -e # Exit on failure
 
-cargo build --release --target-dir=/tmp/codecrafters-redis-target --manifest-path Cargo.toml
+cargo build --release --target-dir=/tmp/codecrafters-kafka-target --manifest-path Cargo.toml

--- a/solutions/rust/01-vi6/code/.codecrafters/run.sh
+++ b/solutions/rust/01-vi6/code/.codecrafters/run.sh
@@ -8,4 +8,4 @@
 
 set -e # Exit on failure
 
-exec /tmp/codecrafters-redis-target/release/redis-starter-rust "$@"
+exec /tmp/codecrafters-kafka-target/release/kafka-starter-rust "$@"

--- a/solutions/rust/01-vi6/code/Cargo.lock
+++ b/solutions/rust/01-vi6/code/Cargo.lock
@@ -189,7 +189,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "redis-starter-rust"
+name = "kafka-starter-rust"
 version = "0.1.0"
 dependencies = [
  "anyhow",

--- a/solutions/rust/01-vi6/code/Cargo.toml
+++ b/solutions/rust/01-vi6/code/Cargo.toml
@@ -6,7 +6,7 @@
 #
 # DON'T EDIT THIS!
 [package]
-name = "redis-starter-rust"
+name = "kafka-starter-rust"
 version = "0.1.0"
 authors = ["Codecrafters <hello@codecrafters.io>"]
 edition = "2021"

--- a/solutions/rust/01-vi6/code/your_program.sh
+++ b/solutions/rust/01-vi6/code/your_program.sh
@@ -14,11 +14,11 @@ set -e # Exit early if any commands fail
 # - Edit .codecrafters/compile.sh to change how your program compiles remotely
 (
   cd "$(dirname "$0")" # Ensure compile steps are run within the repository directory
-  cargo build --release --target-dir=/tmp/codecrafters-redis-target --manifest-path Cargo.toml
+  cargo build --release --target-dir=/tmp/codecrafters-kafka-target --manifest-path Cargo.toml
 )
 
 # Copied from .codecrafters/run.sh
 #
 # - Edit this to change how your program runs locally
 # - Edit .codecrafters/run.sh to change how your program runs remotely
-exec /tmp/codecrafters-redis-target/release/redis-starter-rust "$@"
+exec /tmp/codecrafters-kafka-target/release/kafka-starter-rust "$@"

--- a/starter_templates/rust/code/.codecrafters/compile.sh
+++ b/starter_templates/rust/code/.codecrafters/compile.sh
@@ -8,4 +8,4 @@
 
 set -e # Exit on failure
 
-cargo build --release --target-dir=/tmp/codecrafters-redis-target --manifest-path Cargo.toml
+cargo build --release --target-dir=/tmp/codecrafters-kafka-target --manifest-path Cargo.toml

--- a/starter_templates/rust/code/.codecrafters/run.sh
+++ b/starter_templates/rust/code/.codecrafters/run.sh
@@ -8,4 +8,4 @@
 
 set -e # Exit on failure
 
-exec /tmp/codecrafters-redis-target/release/redis-starter-rust "$@"
+exec /tmp/codecrafters-kafka-target/release/kafka-starter-rust "$@"

--- a/starter_templates/rust/code/Cargo.lock
+++ b/starter_templates/rust/code/Cargo.lock
@@ -189,7 +189,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "redis-starter-rust"
+name = "kafka-starter-rust"
 version = "0.1.0"
 dependencies = [
  "anyhow",

--- a/starter_templates/rust/code/Cargo.toml
+++ b/starter_templates/rust/code/Cargo.toml
@@ -6,7 +6,7 @@
 #
 # DON'T EDIT THIS!
 [package]
-name = "redis-starter-rust"
+name = "kafka-starter-rust"
 version = "0.1.0"
 authors = ["Codecrafters <hello@codecrafters.io>"]
 edition = "2021"


### PR DESCRIPTION
Hello!

I noticed that the project name for the Rust based exercises used Redis instead of Kafka. This should fix that (although I don't know if any other tooling outside of the repo depends on the project name).