### PR TITLE
Add stage descriptions for fetch extension

### DIFF
--- a/course-definition.yml
+++ b/course-definition.yml
@@ -705,7 +705,6 @@ stages:
       - The correlation ID in the response header matches the correlation ID in the request header.
       - The error code in the response body is `0` (No Error).
       - The `throttle_time_ms` field in the response is present (any value is accepted).
-      - The `session_id` field in the response is `0`.
       - The `responses` field in the response has 1 element, and in that element:
         - The `topic_id` field matches what was sent in the request.
         - The `partitions` array has 1 element, and in that element:
@@ -723,18 +722,79 @@ stages:
   - slug: "cm4"
     primary_extension_slug: "consuming-messages"
     name: "Fetch with an empty topic"
-    difficulty: hard
+    difficulty: medium
     description_md: |-
-      🚧 **We're still working on tests for this stage!**.
+      In this stage, you'll implement the Fetch response for a topic with no messages.
+
+      🚧 **We're still working on instructions for this stage**. You can find notes on how the tester works below.
+
+      In the meantime, please use
+      [this link](https://forum.codecrafters.io/new-topic?category=Challenges&tags=challenge%3Akafka&title=Question+about+cm4%3A+Fetch+with+an+empty+topic&body=%3Cyour+question+here%3E)
+      to ask questions on the forum.
+
+      ### Tests
+
+      The tester will execute your program like this:
+
+      ```bash
+      $ ./your_program.sh
+      ```
+
+      It'll then connect to your server on port 9092 and send a `Fetch` (v16) request. The request will contain a single topic with a topic ID that exists. However, the topic has no messages assigned to it (i.e. the log file is empty).
+
+      The tester will validate that:
+
+      - The first 4 bytes of your response (the "message length") are valid.
+      - The correlation ID in the response header matches the correlation ID in the request header.
+      - The error code in the response body is `0` (No Error).
+      - The `throttle_time_ms` field in the response is present (any value is accepted).
+      - The `responses` field in the response has 1 element, and in that element:
+        - The `topic_id` field matches what was sent in the request.
+        - The `partitions` array has 1 element, and in that element:
+          - The `partition_index` field is `0`.
+          - The `error_code` field is `0` (No Error).
+          - The `records` array has `0` elements.
+
     marketing_md: |-
-      In this stage, you'll implement the Fetch response for a topic with multiple messages.
+      In this stage, you'll implement the Fetch response for a topic with no messages.
 
   - slug: "eg2"
     primary_extension_slug: "consuming-messages"
     name: "Fetch single message from disk"
     difficulty: hard
     description_md: |-
-      🚧 **We're still working on tests for this stage!**.
+      In this stage, you'll implement the Fetch response for a topic with a single message, reading it from disk.
+
+      🚧 **We're still working on instructions for this stage**. You can find notes on how the tester works below.
+
+      In the meantime, please use
+      [this link](https://forum.codecrafters.io/new-topic?category=Challenges&tags=challenge%3Akafka&title=Question+about+eg2%3A+Fetch+single+message+from+disk&body=%3Cyour+question+here%3E)
+      to ask questions on the forum.
+
+      ### Tests
+
+      The tester will execute your program like this:
+
+      ```bash
+      $ ./your_program.sh
+      ```
+
+      It'll then connect to your server on port 9092 and send a `Fetch` (v16) request. The request will contain a single topic with a topic ID that exists. The topic has a single message assigned to it.
+
+      The tester will validate that:
+
+      - The first 4 bytes of your response (the "message length") are valid.
+      - The correlation ID in the response header matches the correlation ID in the request header.
+      - The error code in the response body is `0` (No Error).
+      - The `throttle_time_ms` field in the response is present (any value is accepted).
+      - The `responses` field in the response has 1 element, and in that element:
+        - The `topic_id` field matches what was sent in the request.
+        - The `partitions` array has 1 element, and in that element:
+          - The `partition_index` field is `0`.
+          - The `error_code` field is `0` (No Error).
+          - The `records` array has 1 element.
+            - The entire `RecordBatch` content is read from disk. (We will compare the contents of the `RecordBatch` with the contents of the log file to verify this.)
+
     marketing_md: |-
       In this stage, you'll implement the Fetch response for a topic with a single message, reading it from disk.
 
@@ -743,6 +803,37 @@ stages:
     name: "Fetch multiple messages from disk"
     difficulty: hard
     description_md: |-
-      🚧 **We're still working on tests for this stage!**.
+      In this stage, you'll implement the Fetch response for a topic with multiple messages, reading them from disk.
+
+      🚧 **We're still working on instructions for this stage**. You can find notes on how the tester works below.
+
+      In the meantime, please use
+      [this link](https://forum.codecrafters.io/new-topic?category=Challenges&tags=challenge%3Akafka&title=Question+about+fd8%3A+Fetch+multiple+messages+from+disk&body=%3Cyour+question+here%3E)
+      to ask questions on the forum.
+
+      ### Tests
+
+      The tester will execute your program like this:
+
+      ```bash
+      $ ./your_program.sh
+      ```
+
+      It'll then connect to your server on port 9092 and send a `Fetch` (v16) request. The request will contain a single topic with a topic ID that exists. The topic has multiple messages assigned to it (but written to a single partition).
+
+      The tester will validate that:
+
+      - The first 4 bytes of your response (the "message length") are valid.
+      - The correlation ID in the response header matches the correlation ID in the request header.
+      - The error code in the response body is `0` (No Error).
+      - The `throttle_time_ms` field in the response is present (any value is accepted).
+      - The `responses` field in the response has 1 element, and in that element:
+        - The `topic_id` field matches what was sent in the request.
+        - The `partitions` array has 1 element, and in that element:
+          - The `partition_index` field is `0`.
+          - The `error_code` field is `0` (No Error).
+          - The `records` array has the correct number of elements.
+            - The entire `RecordBatch` content is read from disk. (We will compare the contents of the `RecordBatch` with the contents of the log file to verify this.)
+
     marketing_md: |-
       In this stage, you'll implement the Fetch response for a topic with multiple messages, reading them from disk.


### PR DESCRIPTION
This pull request adds stage descriptions for the last few stages in the fetch extension. The stages include "Fetch with an empty topic", "Fetch single message from disk", and "Fetch multiple messages from disk". Each stage description provides an overview of the stage and instructions for implementing the Fetch response for different scenarios. The descriptions also include information about the tests that will be executed to validate the implementation.