### PR TITLE
Update stage descriptions to expect `throttle_time_ms` field to be 0

### DIFF
--- a/course-definition.yml
+++ b/course-definition.yml
@@ -657,7 +657,7 @@ stages:
       - The first 4 bytes of your response (the "message length") are valid.
       - The correlation ID in the response header matches the correlation ID in the request header.
       - The error code in the response body is `0` (No Error).
-      - The `throttle_time_ms` field in the response is present (any value is accepted).
+      - The `throttle_time_ms` field in the response is `0`.
       - The `session_id` field in the response is `0`.
       - The `responses` field in the response has 0 elements (since the request had an empty array of topics).
 
@@ -704,7 +704,7 @@ stages:
       - The first 4 bytes of your response (the "message length") are valid.
       - The correlation ID in the response header matches the correlation ID in the request header.
       - The error code in the response body is `0` (No Error).
-      - The `throttle_time_ms` field in the response is present (any value is accepted).
+      - The `throttle_time_ms` field in the response is `0`.
       - The `responses` field in the response has 1 element, and in that element:
         - The `topic_id` field matches what was sent in the request.
         - The `partitions` array has 1 element, and in that element:
@@ -747,7 +747,7 @@ stages:
       - The first 4 bytes of your response (the "message length") are valid.
       - The correlation ID in the response header matches the correlation ID in the request header.
       - The error code in the response body is `0` (No Error).
-      - The `throttle_time_ms` field in the response is present (any value is accepted).
+      - The `throttle_time_ms` field in the response is `0`.
       - The `responses` field in the response has 1 element, and in that element:
         - The `topic_id` field matches what was sent in the request.
         - The `partitions` array has 1 element, and in that element:
@@ -792,7 +792,7 @@ stages:
       - The first 4 bytes of your response (the "message length") are valid.
       - The correlation ID in the response header matches the correlation ID in the request header.
       - The error code in the response body is `0` (No Error).
-      - The `throttle_time_ms` field in the response is present (any value is accepted).
+      - The `throttle_time_ms` field in the response is `0`.
       - The `responses` field in the response has 1 element, and in that element:
         - The `topic_id` field matches what was sent in the request.
         - The `partitions` array has 1 element, and in that element:
@@ -838,7 +838,7 @@ stages:
       - The first 4 bytes of your response (the "message length") are valid.
       - The correlation ID in the response header matches the correlation ID in the request header.
       - The error code in the response body is `0` (No Error).
-      - The `throttle_time_ms` field in the response is present (any value is accepted).
+      - The `throttle_time_ms` field in the response is `0`.
       - The `responses` field in the response has 1 element, and in that element:
         - The `topic_id` field matches what was sent in the request.
         - The `partitions` array has 1 element, and in that element:


### PR DESCRIPTION
This pull request updates the stage descriptions to mention that we expect the `throttle_time_ms` field in the response to be `0`. This ensures that the `throttle_time_ms` field is correctly handled and validated in the response.