### PR TITLE
[Kafka] CC-1645: Upgrade Rust to 1.85 

### DIFF
--- a/compiled_starters/rust/.codecrafters/run.sh
+++ b/compiled_starters/rust/.codecrafters/run.sh
@@ -6,4 +6,6 @@
 #
 # Learn more: https://codecrafters.io/program-interface
 
+set -e # Exit on failure
+
 exec /tmp/codecrafters-build-kafka-rust/release/codecrafters-kafka "$@"

--- a/compiled_starters/rust/README.md
+++ b/compiled_starters/rust/README.md
@@ -27,7 +27,7 @@ That's all!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `cargo (1.82)` installed locally
+1. Ensure you have `cargo (1.85)` installed locally
 1. Run `./your_program.sh` to run your Kafka broker, which is implemented in
    `src/main.rs`. This command compiles your Rust project, so it might be slow
    the first time you run it. Subsequent runs will be fast.

--- a/compiled_starters/rust/codecrafters.yml
+++ b/compiled_starters/rust/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Rust version used to run your code
 # on Codecrafters.
 #
-# Available versions: rust-1.82
-language_pack: rust-1.82
+# Available versions: rust-1.85
+language_pack: rust-1.85

--- a/dockerfiles/rust-1.85.Dockerfile
+++ b/dockerfiles/rust-1.85.Dockerfile
@@ -1,0 +1,13 @@
+# syntax=docker/dockerfile:1.7-labs
+FROM rust:1.85-bookworm
+
+# Rebuild the container if these files change
+ENV CODECRAFTERS_DEPENDENCY_FILE_PATHS="Cargo.toml,Cargo.lock"
+
+WORKDIR /app
+
+# .git & README.md are unique per-repository. We ignore them on first copy to prevent cache misses
+COPY --exclude=.git --exclude=README.md . /app
+
+# This runs cargo build
+RUN .codecrafters/compile.sh

--- a/solutions/rust/01-vi6/code/.codecrafters/run.sh
+++ b/solutions/rust/01-vi6/code/.codecrafters/run.sh
@@ -6,4 +6,6 @@
 #
 # Learn more: https://codecrafters.io/program-interface
 
+set -e # Exit on failure
+
 exec /tmp/codecrafters-build-kafka-rust/release/codecrafters-kafka "$@"

--- a/solutions/rust/01-vi6/code/README.md
+++ b/solutions/rust/01-vi6/code/README.md
@@ -27,7 +27,7 @@ That's all!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `cargo (1.82)` installed locally
+1. Ensure you have `cargo (1.85)` installed locally
 1. Run `./your_program.sh` to run your Kafka broker, which is implemented in
    `src/main.rs`. This command compiles your Rust project, so it might be slow
    the first time you run it. Subsequent runs will be fast.

--- a/solutions/rust/01-vi6/code/codecrafters.yml
+++ b/solutions/rust/01-vi6/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Rust version used to run your code
 # on Codecrafters.
 #
-# Available versions: rust-1.82
-language_pack: rust-1.82
+# Available versions: rust-1.85
+language_pack: rust-1.85

--- a/starter_templates/rust/code/.codecrafters/run.sh
+++ b/starter_templates/rust/code/.codecrafters/run.sh
@@ -6,4 +6,6 @@
 #
 # Learn more: https://codecrafters.io/program-interface
 
+set -e # Exit on failure
+
 exec /tmp/codecrafters-build-kafka-rust/release/codecrafters-kafka "$@"

--- a/starter_templates/rust/config.yml
+++ b/starter_templates/rust/config.yml
@@ -1,3 +1,3 @@
 attributes:
-  required_executable: cargo (1.82)
+  required_executable: cargo (1.85)
   user_editable_file: src/main.rs


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new container image optimized for Rust 1.85, ensuring a smoother build process.

- **Documentation**
  - Updated tool installation guidelines to require the latest Cargo (version 1.85).

- **Chores**
  - Enhanced script reliability by configuring them to exit immediately on errors.
  - Upgraded configuration settings to support the updated Rust environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->