### PR TITLE
Clarify the `partition_index` requirement in #fd8

### DIFF
--- a/course-definition.yml
+++ b/course-definition.yml
@@ -896,7 +896,7 @@ stages:
       - The `responses` field in the response has 1 element, and in that element:
         - The `topic_id` field matches what was sent in the request.
         - The `partitions` array has 1 element, and in that element:
-          - The `partition_index` field is `0`.
+          - The `partition_index` field is `0`, which matches what was sent in the request.
           - The `error_code` field is `0` (No Error).
           - The `records` array has the correct number of elements.
             - The entire `RecordBatch` content is read from disk. (We will compare the contents of the `RecordBatch` with the contents of the log file to verify this.)

--- a/course-definition.yml
+++ b/course-definition.yml
@@ -896,7 +896,7 @@ stages:
       - The `responses` field in the response has 1 element, and in that element:
         - The `topic_id` field matches what was sent in the request.
         - The `partitions` array has 1 element, and in that element:
-          - The `partition_index` field is `0`, which matches what was sent in the request.
+          - The `partition_index` field matches what was sent in the request.
           - The `error_code` field is `0` (No Error).
           - The `records` array has the correct number of elements.
             - The entire `RecordBatch` content is read from disk. (We will compare the contents of the `RecordBatch` with the contents of the log file to verify this.)


### PR DESCRIPTION
Context: [Question about fd8: Fetch multiple messages from disk - Expected partitions.length to be 1, got 2](https://forum.codecrafters.io/t/question-about-fd8-fetch-multiple-messages-from-disk-expected-partitions-length-to-be-1-got-2/9988)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation for message fetching to ensure the partition index in responses matches the value sent in requests, rather than always expecting zero.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->