### PR TITLE
Add the sort-topics-by-name requirement in instructions #wq2

### DIFF
--- a/stage_descriptions/listing-partitions-05-wq2.md
+++ b/stage_descriptions/listing-partitions-05-wq2.md
@@ -14,12 +14,13 @@ The tester will execute your program like this:
 $ ./your_program.sh /tmp/server.properties
 ```
 
-It'll then connect to your server on port 9092 and send a `DescribeTopicPartitions` (v0) request. The request will contain 3 topic names. The topics exist and have 1 or 2 partitions assigned to each.
+It'll then connect to your server on port 9092 and send a `DescribeTopicPartitions` (v0) request. The request will contain 2 topic names. The topics exist and have 1 or 2 partitions assigned to each.
 
 The tester will validate that:
 
 - The first 4 bytes of your response (the "message length") are valid.
 - The correlation ID in the response header matches the correlation ID in the request header.
+- The topics are sorted alphabetically by topic name.
 - The error code in the topic response body is `0` (NO_ERROR).
 - The `topic_name` field in the topic response should be equal to the topic name sent in the request.
 - The `topic_id` field in the topic response should be equal to the topic UUID of the topic.


### PR DESCRIPTION
Context:

https://forum.codecrafters.io/t/question-about-wq2-describetopicpartition-with-multiple-topics/15332

Source:

https://github.com/apache/kafka/blob/24ea7e0b0093999a540620681b9dd199eb588cae/core/src/main/java/kafka/server/handlers/DescribeTopicPartitionsRequestHandler.java#L92-L92

<img width="1704" height="532" alt="image" src="https://github.com/user-attachments/assets/1e9c19af-3654-439c-88ea-bb1ba7354514" />

https://github.com/codecrafters-io/kafka-tester/blob/939396aafd68fe8f0e74ab19c646534217832ef6/internal/response_assertions/describe_topic_partitions_response_assertion.go#L57-L60

<img width="886" height="200" alt="image" src="https://github.com/user-attachments/assets/2f9cd6ef-1b75-4647-94fc-39b1e37281ca" />


