### PR TITLE
Standardize 'ApiVersions' terminology in course-definition.yml

### DIFF
--- a/course-definition.yml
+++ b/course-definition.yml
@@ -98,7 +98,7 @@ stages:
       In this stage, you'll start encoding your response to the `APIVersions` requests.
 
   - slug: "pv1"
-    name: "Handle APIVersions requests"
+    name: "Handle ApiVersions requests"
     difficulty: hard
     marketing_md: |-
       In this stage, you'll need to implement the `APIVersions:V4` response.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Standardizes the stage name for `pv1` to use `ApiVersions` in `course-definition.yml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ba6611aaf809ee4f8df6ddfbaeda365fea5257de. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->