### PR TITLE
Fixes in produce stages instructions

### DIFF
--- a/stage_descriptions/producing-messages-01-xz1.md
+++ b/stage_descriptions/producing-messages-01-xz1.md
@@ -1,6 +1,6 @@
 In this stage, you'll implement adding the Produce API to the APIVersions response.
 
-## The Produce API
+### The Produce API
 
 The [Produce API](https://kafka.apache.org/protocol#The_Messages_Produce) (API key `0`) is used to produce messages to a Kafka topic.
 
@@ -11,7 +11,7 @@ We've created an interactive protocol inspector for the request & response struc
 
 In this stage, you'll only need to add an entry for the `Produce` API to the APIVersions response you implemented in earlier stages. This lets clients know that your broker supports the `Produce` API. We'll get to responding to `Produce` requests in later stages.
 
-## Tests
+### Tests
 
 The tester will execute your program like this:
 
@@ -29,7 +29,7 @@ The tester will validate that:
 - The response body contains at least one entry for the API key `0` (`Produce`).
 - The `MaxVersion` for the `Produce` API is at least 11.
 
-## Notes
+### Notes
 
 - You don't have to implement support for handling `Produce` requests in this stage. We'll get to this in later stages.
 - You'll still need to include the entry for `APIVersions` in your response to pass earlier stages.

--- a/stage_descriptions/producing-messages-02-zf2.md
+++ b/stage_descriptions/producing-messages-02-zf2.md
@@ -1,6 +1,6 @@
 In this stage, you'll implement the Produce response for invalid topics or partitions.
 
-## Produce API Response for Invalid Topics or Partitions
+### Produce API Response for Invalid Topics or Partitions
 
 When a Kafka broker receives a `Produce` request, it needs to validate that both the topic and partition exist. If either the topic or partition doesn't exist, it returns an appropriate error code and response.
 
@@ -11,7 +11,7 @@ We've created an interactive protocol inspector for the request & response struc
 - 🔎 [Produce Request (v11)](example.com)
 - 🔎 [Produce Response (v11) - Invalid Topic](example.com)
 
-## Tests
+### Tests
 
 The tester will execute your program like this:
 
@@ -35,7 +35,7 @@ The tester will validate that:
     - The `log_append_time_ms` field is `-1`.
     - The `log_start_offset` field is `-1`.
 
-## Notes
+### Notes
 
 - You'll need to parse the `Produce` request in this stage to get the topic name and partition to send in the response.
 - You can hardcode the error response in this stage. We'll get to actually checking for valid topics and partitions in later stages.

--- a/stage_descriptions/producing-messages-03-gg1.md
+++ b/stage_descriptions/producing-messages-03-gg1.md
@@ -1,6 +1,6 @@
 In this stage, you'll implement the Produce response for valid topics and partitions.
 
-## Produce API Response for Valid Topics
+### Produce API Response for Valid Topics
 
 When a Kafka broker receives a `Produce` request, it needs to validate that both the topic and partition exist. If either the topic or partition doesn't exist, it returns an appropriate error code and response.
 
@@ -19,7 +19,7 @@ To validate that a partition exists, the broker reads the same `__cluster_metada
 We've also created an interactive protocol inspector for the `__cluster_metadata` topic's log file:
 - 🔎 [Cluster Metadata Log File](https://binspec.org/kafka-cluster-metadata)
 
-## Tests
+### Tests
 
 The tester will execute your program like this:
 
@@ -43,7 +43,7 @@ The tester will validate that:
     - The `log_append_time_ms` field is `-1` (signifying that the timestamp is the latest).
     - The `log_start_offset` field is `0`.
 
-## Notes
+### Notes
 
 - The official docs for the `Produce` API can be found [here](https://kafka.apache.org/protocol.html#The_Messages_Produce). Make sure to scroll down to the "(Version: 11)" section.
 - The official Kafka docs don't cover the structure of records inside the `__cluster_metadata` topic, but you can find the definitions in the Kafka source code [here](https://github.com/apache/kafka/tree/5b3027dfcbcb62d169d4b4421260226e620459af/metadata/src/main/resources/common/metadata).

--- a/stage_descriptions/producing-messages-04-ls8.md
+++ b/stage_descriptions/producing-messages-04-ls8.md
@@ -1,12 +1,12 @@
 In this stage, you'll implement producing a single record to disk.
 
-## Producing records
+### Producing records
 
 When a Kafka broker receives a `Produce` request, it needs to validate that the topic and partition exist (using the `__cluster_metadata` topic's log file), store the record in the appropriate log file using Kafka's on-disk format, and return a successful response.
 
 The record must be persisted to the topic's log file at `<log-dir>/<topic-name>-<partition-index>/00000000000000000000.log` using Kafka's [RecordBatch format](https://kafka.apache.org/documentation/#recordbatch).
 
-## Tests
+### Tests
 
 The tester will execute your program like this:
 
@@ -31,7 +31,7 @@ The tester will validate that:
     - The `log_start_offset` field is `0`.
 - The record is persisted to the appropriate log file on disk at `<log-dir>/<topic-name>-<partition-index>/00000000000000000000.log`.
 
-## Notes
+### Notes
 
 - The on-disk log files must be stored in [RecordBatch](https://kafka.apache.org/documentation/#recordbatch) format. You should write each `RecordBatch` from the request directly to the log file of the appropriate topic's partition.
 - The official docs for the `Produce` API can be found [here](https://kafka.apache.org/protocol.html#The_Messages_Produce). Make sure to scroll down to the "(Version: 11)" section.

--- a/stage_descriptions/producing-messages-05-yd8.md
+++ b/stage_descriptions/producing-messages-05-yd8.md
@@ -1,6 +1,6 @@
 In this stage, you'll implement producing multiple records in a single request.
 
-## Producing multiple records
+### Producing multiple records
 
 When a Kafka broker receives a `Produce` request containing a `RecordBatch` with multiple records, it needs to validate that the topic and partition exist, assign sequential offsets to each record within the batch, and store the entire batch to the log file. The `RecordBatch` containing multiple records must be stored as a single unit to the topic's log file at `<log-dir>/<topic-name>-<partition-index>/00000000000000000000.log`.
 
@@ -9,7 +9,7 @@ We've created an interactive protocol inspector for the request & response struc
 - 🔎 [Produce Request (v11)](example.com)
 - 🔎 [Produce Response (v11)](example.com)
 
-## Tests
+### Tests
 
 The tester will execute your program like this:
 
@@ -35,7 +35,7 @@ The tester will validate that:
   
 - The RecordBatch sent in the request is written in `<log-dir>/<topic-name>-<partition-index>/00000000000000000000.log`.
 
-## Notes
+### Notes
 
 - The on-disk log files must be stored in [RecordBatch](https://kafka.apache.org/documentation/#recordbatch) format. You should write each `RecordBatch` from the request directly to the log file of the appropriate topic's partition.
 - The official docs for the `Produce` API can be found [here](https://kafka.apache.org/protocol.html#The_Messages_Produce). Make sure to scroll down to the "(Version: 11)" section.

--- a/stage_descriptions/producing-messages-06-ct4.md
+++ b/stage_descriptions/producing-messages-06-ct4.md
@@ -1,6 +1,6 @@
 In this stage, you'll implement producing to multiple partitions of the same topic.
 
-## Producing to multiple partitions
+### Producing to multiple partitions
 
 When a Kafka broker receives a `Produce` request targeting multiple partitions of the same topic, it needs to validate that the topic and all partitions exist, write records to each partition's log file independently, and return a response containing results for all partitions.
 
@@ -9,7 +9,7 @@ We've created an interactive protocol inspector for the request & response struc
 - 🔎 [Produce Request (v11)](example.com)
 - 🔎 [Produce Response (v11)](example.com)
 
-## Tests
+### Tests
 
 The tester will execute your program like this:
 
@@ -34,7 +34,7 @@ The tester will validate that:
     - The `log_start_offset` field is `0`.
 - Each RecordBatch is persisted to the appropriate log file on disk at `<log-dir>/<topic-name>-<partition-index>/00000000000000000000.log`.
 
-## Notes
+### Notes
 
 - The on-disk log files must be stored in [RecordBatch](https://kafka.apache.org/documentation/#recordbatch) format. You should write each `RecordBatch` from the request directly to the log file of the appropriate topic's partition.
 - The official docs for the `Produce` API can be found [here](https://kafka.apache.org/protocol.html#The_Messages_Produce). Make sure to scroll down to the "(Version: 11)" section.

--- a/stage_descriptions/producing-messages-07-ov0.md
+++ b/stage_descriptions/producing-messages-07-ov0.md
@@ -1,6 +1,6 @@
 In this stage, you'll implement producing to multiple partitions of multiple topics.
 
-## Producing to multiple partitions of multiple topics
+### Producing to multiple partitions of multiple topics
 
 When a Kafka broker receives a `Produce` request targeting multiple partitions of multiple topics, it needs to validate that all topics and partitions exist, write records to each partition's log file independently, and return a response containing results for all topics and partitions.
 
@@ -9,7 +9,7 @@ We've created an interactive protocol inspector for the request & response struc
 - 🔎 [Produce Request (v11)](example.com)
 - 🔎 [Produce Response (v11)](example.com)
 
-## Tests
+### Tests
 
 The tester will execute your program like this:
 
@@ -34,7 +34,7 @@ The tester will validate that:
     - The `log_start_offset` field is `0`.
 - Each RecordBatch is persisted to the appropriate log file on disk at `<log-dir>/<topic-name>-<partition-index>/00000000000000000000.log`.
 
-## Notes
+### Notes
 
 - The on-disk log files must be stored in [RecordBatch](https://kafka.apache.org/documentation/#recordbatch) format. You should write each `RecordBatch` from the request directly to the log file of the appropriate topic's partition.
 - The official docs for the `Produce` API can be found [here](https://kafka.apache.org/protocol.html#The_Messages_Produce). Make sure to scroll down to the "(Version: 11)" section.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Standardizes Produce stage docs: heading levels, shell prompts, and error-code formatting, with minor consistency tweaks across all stages.
> 
> - **Docs — Produce stages**:
>   - Standardize headings to `###`.
>   - Prefix shell command examples with `$`.
>   - Normalize error code names by wrapping in backticks (e.g., `NO_ERROR`, `UNKNOWN_TOPIC_OR_PARTITION`).
>   - Minor consistency/wording fixes across stage descriptions; no behavioral changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 90ee4c04cb516e2a171fb410afaa6eccdccaf4a7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->