### PR TITLE
Fix example response in listing-partitions-03-ea7.md 

### DIFF
--- a/stage_descriptions/listing-partitions-03-ea7.md
+++ b/stage_descriptions/listing-partitions-03-ea7.md
@@ -73,9 +73,9 @@ a3 b4 c5 d6  //
 00 00 00 01  // leader_id:                    1
 00 00 00 00  // leader_epoch:                 0
 02           // replica_nodes:                1 element
-01           //                               broker 1
+00 00 00 01  //                               broker 1
 02           // isr_nodes:                    1 element
-01           //                               broker 1
+00 00 00 01  //                               broker 1
 01           // eligible_leader_replicas:     0 elements (empty)
 01           // last_known_elr:               0 elements (empty)
 01           // offline_replicas:             0 elements (empty)


### PR DESCRIPTION
Context:

https://backend.codecrafters.io/admin/course_stage_feedback_submissions/c8ab9191-5df9-48a7-b570-655df39d8a4b/edit

---

Verification:

https://binspec.org/kafka-describe-topic-partitions-response-v0?highlight=53-56

<img width="1346" height="596" alt="image" src="https://github.com/user-attachments/assets/c3d33c9e-a05a-493a-8242-1dc3fd715624" />

<img width="1342" height="560" alt="image" src="https://github.com/user-attachments/assets/72267136-b885-4472-9a7a-7e475949853d" />

Thanks to @dayshah for highlighting the issue!

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that corrects the example bytes for `replica_nodes`/`isr_nodes` broker IDs; no runtime behavior changes.
> 
> **Overview**
> Fixes the `DescribeTopicPartitions` response example in `stage_descriptions/listing-partitions-03-ea7.md` by correcting the `replica_nodes` and `isr_nodes` entries to show the proper 4-byte `INT32` encoding for broker id `1` (`00 00 00 01`) instead of a single-byte `01`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 092cb9da307b9a02624dea66ff7921cc76b091e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->