### PR TITLE
CC-2208: Upgrade Zig to 0.16

### DIFF
--- a/compiled_starters/zig/README.md
+++ b/compiled_starters/zig/README.md
@@ -27,7 +27,7 @@ That's all!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `zig (0.15)` installed locally
+1. Ensure you have `zig (0.16)` installed locally
 1. Run `./your_program.sh` to run your Kafka broker, which is implemented in
    `src/main.zig`.
 1. Commit your changes and run `git push origin master` to submit your solution

--- a/compiled_starters/zig/build.zig.zon
+++ b/compiled_starters/zig/build.zig.zon
@@ -8,7 +8,7 @@
 
     // Tracks the earliest Zig version that the package considers to be a
     // supported use case.
-    .minimum_zig_version = "0.15.1",
+    .minimum_zig_version = "0.16.0",
 
     // This field is optional.
     // Each dependency must either provide a `url` and `hash`, or a `path`.

--- a/compiled_starters/zig/codecrafters.yml
+++ b/compiled_starters/zig/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Zig version used to run your code
 # on Codecrafters.
 #
-# Available versions: zig-0.15.2
-buildpack: zig-0.15.2
+# Available versions: zig-0.16
+buildpack: zig-0.16

--- a/compiled_starters/zig/src/main.zig
+++ b/compiled_starters/zig/src/main.zig
@@ -1,17 +1,18 @@
 const std = @import("std");
-const net = std.net;
-const posix = std.posix;
+const net = std.Io.net;
 
-pub fn main() !void {
+pub fn main(init: std.process.Init) !void {
+    const io = init.io;
+
     // You can use print statements as follows for debugging, they'll be visible when running tests.
-    std.debug.print("Logs from your program will appear here!\n", .{});
+    try std.Io.File.writeStreamingAll(std.Io.File.stderr(), io, "Logs from your program will appear here!\n");
 
     // TODO: Uncomment the code below to pass the first stage
-    // const address = try net.Address.resolveIp("127.0.0.1", 9092);
-    // var listener = try address.listen(.{
+    // const address = try net.IpAddress.parse("127.0.0.1", 9092);
+    // var listener = try address.listen(io, .{
     //     .reuse_address = true,
     // });
-    // defer listener.deinit();
+    // defer listener.deinit(io);
     //
-    // _ = try listener.accept();
+    // _ = try listener.accept(io);
 }

--- a/dockerfiles/zig-0.16.Dockerfile
+++ b/dockerfiles/zig-0.16.Dockerfile
@@ -1,0 +1,34 @@
+# syntax=docker/dockerfile:1.7-labs
+FROM debian:trixie
+
+# hadolint ignore=DL3008
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y \
+        curl \
+        xz-utils \
+        && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Download and install Zig
+RUN curl -O https://ziglang.org/download/0.16.0/zig-x86_64-linux-0.16.0.tar.xz \
+    && tar -xf zig-x86_64-linux-0.16.0.tar.xz \
+    && mv zig-x86_64-linux-0.16.0 /usr/local/zig \
+    && rm zig-x86_64-linux-0.16.0.tar.xz
+
+# Add Zig to PATH
+ENV PATH="/usr/local/zig:${PATH}"
+
+ENV CODECRAFTERS_DEPENDENCY_FILE_PATHS="build.zig,build.zig.zon"
+
+WORKDIR /app
+
+# .git & README.md are unique per-repository. We ignore them on first copy to prevent cache misses
+COPY --exclude=.git --exclude=README.md . /app
+
+# This runs zig build
+RUN .codecrafters/compile.sh
+
+# Cache build directory
+RUN mkdir -p /app-cached
+RUN mv /app/.zig-cache /app-cached/.zig-cache || true

--- a/solutions/zig/01-vi6/code/README.md
+++ b/solutions/zig/01-vi6/code/README.md
@@ -27,7 +27,7 @@ That's all!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `zig (0.15)` installed locally
+1. Ensure you have `zig (0.16)` installed locally
 1. Run `./your_program.sh` to run your Kafka broker, which is implemented in
    `src/main.zig`.
 1. Commit your changes and run `git push origin master` to submit your solution

--- a/solutions/zig/01-vi6/code/build.zig.zon
+++ b/solutions/zig/01-vi6/code/build.zig.zon
@@ -8,7 +8,7 @@
 
     // Tracks the earliest Zig version that the package considers to be a
     // supported use case.
-    .minimum_zig_version = "0.15.1",
+    .minimum_zig_version = "0.16.0",
 
     // This field is optional.
     // Each dependency must either provide a `url` and `hash`, or a `path`.

--- a/solutions/zig/01-vi6/code/codecrafters.yml
+++ b/solutions/zig/01-vi6/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Zig version used to run your code
 # on Codecrafters.
 #
-# Available versions: zig-0.15.2
-buildpack: zig-0.15.2
+# Available versions: zig-0.16
+buildpack: zig-0.16

--- a/solutions/zig/01-vi6/code/src/main.zig
+++ b/solutions/zig/01-vi6/code/src/main.zig
@@ -1,13 +1,14 @@
 const std = @import("std");
-const net = std.net;
-const posix = std.posix;
+const net = std.Io.net;
 
-pub fn main() !void {
-    const address = try net.Address.resolveIp("127.0.0.1", 9092);
-    var listener = try address.listen(.{
+pub fn main(init: std.process.Init) !void {
+    const io = init.io;
+
+    const address = try net.IpAddress.parse("127.0.0.1", 9092);
+    var listener = try address.listen(io, .{
         .reuse_address = true,
     });
-    defer listener.deinit();
+    defer listener.deinit(io);
 
-    _ = try listener.accept();
+    _ = try listener.accept(io);
 }

--- a/solutions/zig/01-vi6/diff/src/main.zig.diff
+++ b/solutions/zig/01-vi6/diff/src/main.zig.diff
@@ -1,24 +1,25 @@
-@@ -1,17 +1,13 @@
+@@ -1,18 +1,14 @@
  const std = @import("std");
- const net = std.net;
- const posix = std.posix;
+ const net = std.Io.net;
 
- pub fn main() !void {
+ pub fn main(init: std.process.Init) !void {
+     const io = init.io;
+
 -    // You can use print statements as follows for debugging, they'll be visible when running tests.
--    std.debug.print("Logs from your program will appear here!\n", .{});
-+    const address = try net.Address.resolveIp("127.0.0.1", 9092);
-+    var listener = try address.listen(.{
+-    try std.Io.File.writeStreamingAll(std.Io.File.stderr(), io, "Logs from your program will appear here!\n");
++    const address = try net.IpAddress.parse("127.0.0.1", 9092);
++    var listener = try address.listen(io, .{
 +        .reuse_address = true,
 +    });
-+    defer listener.deinit();
++    defer listener.deinit(io);
 
 -    // TODO: Uncomment the code below to pass the first stage
--    // const address = try net.Address.resolveIp("127.0.0.1", 9092);
--    // var listener = try address.listen(.{
+-    // const address = try net.IpAddress.parse("127.0.0.1", 9092);
+-    // var listener = try address.listen(io, .{
 -    //     .reuse_address = true,
 -    // });
--    // defer listener.deinit();
+-    // defer listener.deinit(io);
 -    //
--    // _ = try listener.accept();
-+    _ = try listener.accept();
+-    // _ = try listener.accept(io);
++    _ = try listener.accept(io);
  }

--- a/starter_templates/zig/code/build.zig.zon
+++ b/starter_templates/zig/code/build.zig.zon
@@ -8,7 +8,7 @@
 
     // Tracks the earliest Zig version that the package considers to be a
     // supported use case.
-    .minimum_zig_version = "0.15.1",
+    .minimum_zig_version = "0.16.0",
 
     // This field is optional.
     // Each dependency must either provide a `url` and `hash`, or a `path`.

--- a/starter_templates/zig/code/src/main.zig
+++ b/starter_templates/zig/code/src/main.zig
@@ -1,17 +1,18 @@
 const std = @import("std");
-const net = std.net;
-const posix = std.posix;
+const net = std.Io.net;
 
-pub fn main() !void {
+pub fn main(init: std.process.Init) !void {
+    const io = init.io;
+
     // You can use print statements as follows for debugging, they'll be visible when running tests.
-    std.debug.print("Logs from your program will appear here!\n", .{});
+    try std.Io.File.writeStreamingAll(std.Io.File.stderr(), io, "Logs from your program will appear here!\n");
 
     // TODO: Uncomment the code below to pass the first stage
-    // const address = try net.Address.resolveIp("127.0.0.1", 9092);
-    // var listener = try address.listen(.{
+    // const address = try net.IpAddress.parse("127.0.0.1", 9092);
+    // var listener = try address.listen(io, .{
     //     .reuse_address = true,
     // });
-    // defer listener.deinit();
+    // defer listener.deinit(io);
     //
-    // _ = try listener.accept();
+    // _ = try listener.accept(io);
 }

--- a/starter_templates/zig/config.yml
+++ b/starter_templates/zig/config.yml
@@ -1,3 +1,3 @@
 attributes:
-  required_executable: zig (0.15)
+  required_executable: zig (0.16)
   user_editable_file: src/main.zig


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Upgrading the Zig toolchain and updating networking/IO APIs can break builds or runtime behavior due to upstream language/stdlib changes, even though the functional Kafka logic is largely untouched.
> 
> **Overview**
> Upgrades the Zig starter/solution templates from **Zig 0.15 to 0.16** by bumping `minimum_zig_version`, updating docs/config (`codecrafters.yml`, required executable), and adding a new `dockerfiles/zig-0.16.Dockerfile` for the build environment.
> 
> Updates `src/main.zig` in starters/solutions to match Zig 0.16 stdlib changes: switches to `std.Io`-based networking (`std.Io.net`, `IpAddress.parse`, `listen/accept/deinit` now take `io`) and replaces debug printing with streaming stderr writes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 755a08ab12c18c643247c9d0e83961c732af2b36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->