### PR TITLE
https://linear.app/codecrafters/issue/CC-2159/replace-git-commands-in-readmes-as-cc-submit

### DIFF
--- a/compiled_starters/c/README.md
+++ b/compiled_starters/c/README.md
@@ -30,5 +30,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `cmake` installed locally
 1. Run `./your_program.sh` to run your Kafka broker, which is implemented in
    `src/main.c`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/compiled_starters/cpp/README.md
+++ b/compiled_starters/cpp/README.md
@@ -30,5 +30,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `cmake` installed locally
 1. Run `./your_program.sh` to run your Kafka broker, which is implemented in
    `src/main.cpp`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/compiled_starters/csharp/README.md
+++ b/compiled_starters/csharp/README.md
@@ -30,5 +30,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `dotnet (9.0)` installed locally
 1. Run `./your_program.sh` to run your Kafka broker, which is implemented in
    `src/main.cs`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/compiled_starters/elixir/README.md
+++ b/compiled_starters/elixir/README.md
@@ -30,5 +30,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `mix` installed locally
 1. Run `./your_program.sh` to run your Kafka broker, which is implemented in
    `lib/main.ex`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/compiled_starters/gleam/README.md
+++ b/compiled_starters/gleam/README.md
@@ -30,5 +30,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `gleam (1.14.0)` installed locally
 1. Run `./your_program.sh` to run your Kafka broker, which is implemented in
    `src/main.gleam`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/compiled_starters/go/README.md
+++ b/compiled_starters/go/README.md
@@ -30,5 +30,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `go (1.26)` installed locally
 1. Run `./your_program.sh` to run your Kafka broker, which is implemented in
    `app/main.go`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/compiled_starters/java/README.md
+++ b/compiled_starters/java/README.md
@@ -31,5 +31,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `mvn` installed locally
 1. Run `./your_program.sh` to run your Kafka broker, which is implemented in
    `src/main/java/Main.java`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/compiled_starters/javascript/README.md
+++ b/compiled_starters/javascript/README.md
@@ -30,5 +30,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `node (25)` installed locally
 1. Run `./your_program.sh` to run your Kafka broker, which is implemented in
    `app/main.js`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/compiled_starters/kotlin/README.md
+++ b/compiled_starters/kotlin/README.md
@@ -31,5 +31,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `gradle (9.4.1)` installed locally
 1. Run `./your_program.sh` to run your Kafka broker, which is implemented in
    `app/src/main/kotlin/App.kt`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/compiled_starters/python/README.md
+++ b/compiled_starters/python/README.md
@@ -30,8 +30,8 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `uv` installed locally
 1. Run `./your_program.sh` to run your Kafka broker, which is implemented in
    `app/main.py`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.
 
 # Troubleshooting
 

--- a/compiled_starters/rust/README.md
+++ b/compiled_starters/rust/README.md
@@ -31,5 +31,5 @@ Note: This section is for stages 2 and beyond.
 1. Run `./your_program.sh` to run your Kafka broker, which is implemented in
    `src/main.rs`. This command compiles your Rust project, so it might be slow
    the first time you run it. Subsequent runs will be fast.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/compiled_starters/scala/README.md
+++ b/compiled_starters/scala/README.md
@@ -31,5 +31,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `scala-cli` installed locally
 1. Run `./your_program.sh` to run your Kafka broker, which is implemented in
    `src/main/scala/codecrafters_kafka/App.scala`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/compiled_starters/typescript/README.md
+++ b/compiled_starters/typescript/README.md
@@ -30,5 +30,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `bun (1.3)` installed locally
 1. Run `./your_program.sh` to run your Kafka broker, which is implemented in
    `app/main.ts`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/compiled_starters/zig/README.md
+++ b/compiled_starters/zig/README.md
@@ -30,5 +30,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `zig (0.16)` installed locally
 1. Run `./your_program.sh` to run your Kafka broker, which is implemented in
    `src/main.zig`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/c/01-vi6/code/README.md
+++ b/solutions/c/01-vi6/code/README.md
@@ -30,5 +30,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `cmake` installed locally
 1. Run `./your_program.sh` to run your Kafka broker, which is implemented in
    `src/main.c`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/cpp/01-vi6/code/README.md
+++ b/solutions/cpp/01-vi6/code/README.md
@@ -30,5 +30,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `cmake` installed locally
 1. Run `./your_program.sh` to run your Kafka broker, which is implemented in
    `src/main.cpp`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/csharp/01-vi6/code/README.md
+++ b/solutions/csharp/01-vi6/code/README.md
@@ -30,5 +30,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `dotnet (9.0)` installed locally
 1. Run `./your_program.sh` to run your Kafka broker, which is implemented in
    `src/main.cs`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/elixir/01-vi6/code/README.md
+++ b/solutions/elixir/01-vi6/code/README.md
@@ -30,5 +30,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `mix` installed locally
 1. Run `./your_program.sh` to run your Kafka broker, which is implemented in
    `lib/main.ex`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/gleam/01-vi6/code/README.md
+++ b/solutions/gleam/01-vi6/code/README.md
@@ -30,5 +30,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `gleam (1.14.0)` installed locally
 1. Run `./your_program.sh` to run your Kafka broker, which is implemented in
    `src/main.gleam`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/go/01-vi6/code/README.md
+++ b/solutions/go/01-vi6/code/README.md
@@ -30,5 +30,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `go (1.26)` installed locally
 1. Run `./your_program.sh` to run your Kafka broker, which is implemented in
    `app/main.go`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/java/01-vi6/code/README.md
+++ b/solutions/java/01-vi6/code/README.md
@@ -31,5 +31,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `mvn` installed locally
 1. Run `./your_program.sh` to run your Kafka broker, which is implemented in
    `src/main/java/Main.java`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/javascript/01-vi6/code/README.md
+++ b/solutions/javascript/01-vi6/code/README.md
@@ -30,5 +30,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `node (25)` installed locally
 1. Run `./your_program.sh` to run your Kafka broker, which is implemented in
    `app/main.js`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/kotlin/01-vi6/code/README.md
+++ b/solutions/kotlin/01-vi6/code/README.md
@@ -31,5 +31,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `gradle (9.4.1)` installed locally
 1. Run `./your_program.sh` to run your Kafka broker, which is implemented in
    `app/src/main/kotlin/App.kt`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/python/01-vi6/code/README.md
+++ b/solutions/python/01-vi6/code/README.md
@@ -30,8 +30,8 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `uv` installed locally
 1. Run `./your_program.sh` to run your Kafka broker, which is implemented in
    `app/main.py`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.
 
 # Troubleshooting
 

--- a/solutions/rust/01-vi6/code/README.md
+++ b/solutions/rust/01-vi6/code/README.md
@@ -31,5 +31,5 @@ Note: This section is for stages 2 and beyond.
 1. Run `./your_program.sh` to run your Kafka broker, which is implemented in
    `src/main.rs`. This command compiles your Rust project, so it might be slow
    the first time you run it. Subsequent runs will be fast.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/scala/01-vi6/code/README.md
+++ b/solutions/scala/01-vi6/code/README.md
@@ -31,5 +31,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `scala-cli` installed locally
 1. Run `./your_program.sh` to run your Kafka broker, which is implemented in
    `src/main/scala/codecrafters_kafka/App.scala`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/typescript/01-vi6/code/README.md
+++ b/solutions/typescript/01-vi6/code/README.md
@@ -30,5 +30,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `bun (1.3)` installed locally
 1. Run `./your_program.sh` to run your Kafka broker, which is implemented in
    `app/main.ts`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/zig/01-vi6/code/README.md
+++ b/solutions/zig/01-vi6/code/README.md
@@ -30,5 +30,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `zig (0.16)` installed locally
 1. Run `./your_program.sh` to run your Kafka broker, which is implemented in
    `src/main.zig`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/starter_templates/all/code/README.md
+++ b/starter_templates/all/code/README.md
@@ -29,8 +29,7 @@ Note: This section is for stages 2 and beyond.
    `{{ user_editable_file }}`.{{# language_is_rust }} This command compiles your
    Rust project, so it might be slow the first time you run it. Subsequent runs
    will be fast.{{/ language_is_rust}}
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test output will be streamed to your terminal.
 
 {{#language_is_python}}
 


### PR DESCRIPTION
https://linear.app/codecrafters/issue/CC-2159/replace-git-commands-in-readmes-as-cc-submit

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that standardizes submission instructions across starter and solution READMEs; no code or build behavior is modified.
> 
> **Overview**
> Standardizes the *stage 2+ submission step* across all Kafka `compiled_starters/*` and `solutions/*` READMEs to use `codecrafters submit` rather than `git push origin master`.
> 
> Updates the shared template (`starter_templates/all/code/README.md`) so future generated READMEs inherit the same `codecrafters submit` instruction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bb0bf7a84bc0020eb55a780225b21bf4e48722b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->