### PR TITLE
https://linear.app/codecrafters/issue/CC-2159/replace-git-commands-in-readmes-as-cc-submit

### DIFF
--- a/compiled_starters/c/README.md
+++ b/compiled_starters/c/README.md
@@ -14,11 +14,11 @@ about handling the network protocol, event loops, TCP sockets and more.
 # Passing the first stage
 
 The entry point for your Kafka implementation is in `src/main.c`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!

--- a/compiled_starters/cpp/README.md
+++ b/compiled_starters/cpp/README.md
@@ -14,11 +14,11 @@ about handling the network protocol, event loops, TCP sockets and more.
 # Passing the first stage
 
 The entry point for your Kafka implementation is in `src/main.cpp`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!

--- a/compiled_starters/csharp/README.md
+++ b/compiled_starters/csharp/README.md
@@ -14,11 +14,11 @@ about handling the network protocol, event loops, TCP sockets and more.
 # Passing the first stage
 
 The entry point for your Kafka implementation is in `src/main.cs`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!

--- a/compiled_starters/elixir/README.md
+++ b/compiled_starters/elixir/README.md
@@ -14,11 +14,11 @@ about handling the network protocol, event loops, TCP sockets and more.
 # Passing the first stage
 
 The entry point for your Kafka implementation is in `lib/main.ex`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!

--- a/compiled_starters/gleam/README.md
+++ b/compiled_starters/gleam/README.md
@@ -14,11 +14,11 @@ about handling the network protocol, event loops, TCP sockets and more.
 # Passing the first stage
 
 The entry point for your Kafka implementation is in `src/main.gleam`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!

--- a/compiled_starters/go/README.md
+++ b/compiled_starters/go/README.md
@@ -14,11 +14,11 @@ about handling the network protocol, event loops, TCP sockets and more.
 # Passing the first stage
 
 The entry point for your Kafka implementation is in `app/main.go`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!

--- a/compiled_starters/java/README.md
+++ b/compiled_starters/java/README.md
@@ -14,12 +14,11 @@ about handling the network protocol, event loops, TCP sockets and more.
 # Passing the first stage
 
 The entry point for your Kafka implementation is in `src/main/java/Main.java`.
-Study and uncomment the relevant code, and push your changes to pass the first
-stage:
+Study and uncomment the relevant code, and then run the command below to execute
+the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!

--- a/compiled_starters/javascript/README.md
+++ b/compiled_starters/javascript/README.md
@@ -14,11 +14,11 @@ about handling the network protocol, event loops, TCP sockets and more.
 # Passing the first stage
 
 The entry point for your Kafka implementation is in `app/main.js`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!

--- a/compiled_starters/kotlin/README.md
+++ b/compiled_starters/kotlin/README.md
@@ -14,12 +14,11 @@ about handling the network protocol, event loops, TCP sockets and more.
 # Passing the first stage
 
 The entry point for your Kafka implementation is in
-`app/src/main/kotlin/App.kt`. Study and uncomment the relevant code, and push
-your changes to pass the first stage:
+`app/src/main/kotlin/App.kt`. Study and uncomment the relevant code, and then
+run the command below to execute the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!

--- a/compiled_starters/python/README.md
+++ b/compiled_starters/python/README.md
@@ -14,11 +14,11 @@ about handling the network protocol, event loops, TCP sockets and more.
 # Passing the first stage
 
 The entry point for your Kafka implementation is in `app/main.py`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!

--- a/compiled_starters/rust/README.md
+++ b/compiled_starters/rust/README.md
@@ -14,11 +14,11 @@ about handling the network protocol, event loops, TCP sockets and more.
 # Passing the first stage
 
 The entry point for your Kafka implementation is in `src/main.rs`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!

--- a/compiled_starters/scala/README.md
+++ b/compiled_starters/scala/README.md
@@ -15,11 +15,10 @@ about handling the network protocol, event loops, TCP sockets and more.
 
 The entry point for your Kafka implementation is in
 `src/main/scala/codecrafters_kafka/App.scala`. Study and uncomment the relevant
-code, and push your changes to pass the first stage:
+code, and then run the command below to execute the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!

--- a/compiled_starters/typescript/README.md
+++ b/compiled_starters/typescript/README.md
@@ -14,11 +14,11 @@ about handling the network protocol, event loops, TCP sockets and more.
 # Passing the first stage
 
 The entry point for your Kafka implementation is in `app/main.ts`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!

--- a/compiled_starters/zig/README.md
+++ b/compiled_starters/zig/README.md
@@ -14,11 +14,11 @@ about handling the network protocol, event loops, TCP sockets and more.
 # Passing the first stage
 
 The entry point for your Kafka implementation is in `src/main.zig`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!

--- a/solutions/c/01-vi6/code/README.md
+++ b/solutions/c/01-vi6/code/README.md
@@ -14,11 +14,11 @@ about handling the network protocol, event loops, TCP sockets and more.
 # Passing the first stage
 
 The entry point for your Kafka implementation is in `src/main.c`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!

--- a/solutions/cpp/01-vi6/code/README.md
+++ b/solutions/cpp/01-vi6/code/README.md
@@ -14,11 +14,11 @@ about handling the network protocol, event loops, TCP sockets and more.
 # Passing the first stage
 
 The entry point for your Kafka implementation is in `src/main.cpp`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!

--- a/solutions/csharp/01-vi6/code/README.md
+++ b/solutions/csharp/01-vi6/code/README.md
@@ -14,11 +14,11 @@ about handling the network protocol, event loops, TCP sockets and more.
 # Passing the first stage
 
 The entry point for your Kafka implementation is in `src/main.cs`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!

--- a/solutions/elixir/01-vi6/code/README.md
+++ b/solutions/elixir/01-vi6/code/README.md
@@ -14,11 +14,11 @@ about handling the network protocol, event loops, TCP sockets and more.
 # Passing the first stage
 
 The entry point for your Kafka implementation is in `lib/main.ex`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!

--- a/solutions/gleam/01-vi6/code/README.md
+++ b/solutions/gleam/01-vi6/code/README.md
@@ -14,11 +14,11 @@ about handling the network protocol, event loops, TCP sockets and more.
 # Passing the first stage
 
 The entry point for your Kafka implementation is in `src/main.gleam`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!

--- a/solutions/go/01-vi6/code/README.md
+++ b/solutions/go/01-vi6/code/README.md
@@ -14,11 +14,11 @@ about handling the network protocol, event loops, TCP sockets and more.
 # Passing the first stage
 
 The entry point for your Kafka implementation is in `app/main.go`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!

--- a/solutions/java/01-vi6/code/README.md
+++ b/solutions/java/01-vi6/code/README.md
@@ -14,12 +14,11 @@ about handling the network protocol, event loops, TCP sockets and more.
 # Passing the first stage
 
 The entry point for your Kafka implementation is in `src/main/java/Main.java`.
-Study and uncomment the relevant code, and push your changes to pass the first
-stage:
+Study and uncomment the relevant code, and then run the command below to execute
+the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!

--- a/solutions/javascript/01-vi6/code/README.md
+++ b/solutions/javascript/01-vi6/code/README.md
@@ -14,11 +14,11 @@ about handling the network protocol, event loops, TCP sockets and more.
 # Passing the first stage
 
 The entry point for your Kafka implementation is in `app/main.js`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!

--- a/solutions/kotlin/01-vi6/code/README.md
+++ b/solutions/kotlin/01-vi6/code/README.md
@@ -14,12 +14,11 @@ about handling the network protocol, event loops, TCP sockets and more.
 # Passing the first stage
 
 The entry point for your Kafka implementation is in
-`app/src/main/kotlin/App.kt`. Study and uncomment the relevant code, and push
-your changes to pass the first stage:
+`app/src/main/kotlin/App.kt`. Study and uncomment the relevant code, and then
+run the command below to execute the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!

--- a/solutions/python/01-vi6/code/README.md
+++ b/solutions/python/01-vi6/code/README.md
@@ -14,11 +14,11 @@ about handling the network protocol, event loops, TCP sockets and more.
 # Passing the first stage
 
 The entry point for your Kafka implementation is in `app/main.py`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!

--- a/solutions/rust/01-vi6/code/README.md
+++ b/solutions/rust/01-vi6/code/README.md
@@ -14,11 +14,11 @@ about handling the network protocol, event loops, TCP sockets and more.
 # Passing the first stage
 
 The entry point for your Kafka implementation is in `src/main.rs`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!

--- a/solutions/scala/01-vi6/code/README.md
+++ b/solutions/scala/01-vi6/code/README.md
@@ -15,11 +15,10 @@ about handling the network protocol, event loops, TCP sockets and more.
 
 The entry point for your Kafka implementation is in
 `src/main/scala/codecrafters_kafka/App.scala`. Study and uncomment the relevant
-code, and push your changes to pass the first stage:
+code, and then run the command below to execute the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!

--- a/solutions/typescript/01-vi6/code/README.md
+++ b/solutions/typescript/01-vi6/code/README.md
@@ -14,11 +14,11 @@ about handling the network protocol, event loops, TCP sockets and more.
 # Passing the first stage
 
 The entry point for your Kafka implementation is in `app/main.ts`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!

--- a/solutions/zig/01-vi6/code/README.md
+++ b/solutions/zig/01-vi6/code/README.md
@@ -14,11 +14,11 @@ about handling the network protocol, event loops, TCP sockets and more.
 # Passing the first stage
 
 The entry point for your Kafka implementation is in `src/main.zig`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!

--- a/starter_templates/all/code/README.md
+++ b/starter_templates/all/code/README.md
@@ -11,11 +11,10 @@ In this challenge, you'll build a toy Kafka clone that's capable of accepting an
 # Passing the first stage
 
 The entry point for your Kafka implementation is in `{{ user_editable_file }}`. Study and uncomment the relevant code, and
-push your changes to pass the first stage:
+then run the command below to execute the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 That's all!


### PR DESCRIPTION
https://linear.app/codecrafters/issue/CC-2159/replace-git-commands-in-readmes-as-cc-submit

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates across starter/solution READMEs; no runtime or build logic changes.
> 
> **Overview**
> Updates the Kafka challenge "Passing the first stage" instructions across compiled starters, solutions, and the shared template to use `codecrafters submit` (and wording about running tests on CodeCrafters servers) instead of `git commit`/`git push` steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1881267662317180b806d3beb4f8525b8e412cdf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->