### PR TITLE
Fix gleam spacing

### DIFF
--- a/compiled_starters/gleam/src/main.gleam
+++ b/compiled_starters/gleam/src/main.gleam
@@ -14,6 +14,7 @@ pub fn main() {
 
   // You can use print statements as follows for debugging, they'll be visible when running tests.
   io.println("Logs from your program will appear here!")
+
   // TODO: Uncomment the code below to pass the first stage
   //
   // let assert Ok(_) =

--- a/solutions/gleam/01-vi6/diff/src/main.gleam.diff
+++ b/solutions/gleam/01-vi6/diff/src/main.gleam.diff
@@ -1,4 +1,4 @@
-@@ -1,27 +1,23 @@
+@@ -1,28 +1,23 @@
  import gleam/io
 
  import gleam/erlang/process
@@ -15,6 +15,13 @@
 
 -  // You can use print statements as follows for debugging, they'll be visible when running tests.
 -  io.println("Logs from your program will appear here!")
++  let assert Ok(_) =
++    glisten.new(fn(_conn) { #(Nil, None) }, fn(state, _msg, _conn) {
++      io.println("Received message!")
++      glisten.continue(state)
++    })
++    |> glisten.start(9092)
+
 -  // TODO: Uncomment the code below to pass the first stage
 -  //
 -  // let assert Ok(_) =
@@ -25,12 +32,5 @@
 -  //   |> glisten.start(9092)
 -  //
 -  // process.sleep_forever()
-+  let assert Ok(_) =
-+    glisten.new(fn(_conn) { #(Nil, None) }, fn(state, _msg, _conn) {
-+      io.println("Received message!")
-+      glisten.continue(state)
-+    })
-+    |> glisten.start(9092)
-+
 +  process.sleep_forever()
  }

--- a/starter_templates/gleam/code/src/main.gleam
+++ b/starter_templates/gleam/code/src/main.gleam
@@ -14,6 +14,7 @@ pub fn main() {
 
   // You can use print statements as follows for debugging, they'll be visible when running tests.
   io.println("Logs from your program will appear here!")
+
   // TODO: Uncomment the code below to pass the first stage
   //
   // let assert Ok(_) =


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation/starter-template adjustments plus an update to the stage-1 solution diff; no production logic or security-sensitive code paths are affected.
> 
> **Overview**
> Updates the Gleam starter `main.gleam` (both `starter_templates` and `compiled_starters`) with a small spacing tweak by inserting a blank line before the stage-1 TODO block.
> 
> Adjusts the stage-1 solution patch (`solutions/gleam/01-vi6/diff/src/main.gleam.diff`) to remove the initial debug `io.println`/commented TODO section and instead include the actual `glisten.new |> glisten.start(9092)` setup followed by `process.sleep_forever()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92f882d83326298ffd6c5f1e4ff5dff916459295. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->